### PR TITLE
Fix copy-paste error

### DIFF
--- a/docs/forms/input-group/index.html
+++ b/docs/forms/input-group/index.html
@@ -169,7 +169,7 @@ function SizesExample() {
         &lt;InputGroup.Text id=&quot;inputGroup-sizing-lg&quot;&gt;Large&lt;/InputGroup.Text&gt;
         &lt;Form.Control
           aria-label=&quot;Large&quot;
-          aria-describedby=&quot;inputGroup-sizing-sm&quot;
+          aria-describedby=&quot;inputGroup-sizing-lg&quot;
         /&gt;
       &lt;/InputGroup&gt;
     &lt;/&gt;


### PR DESCRIPTION
Just a little copy/paste error in inputGroup example

```js
<InputGroup size="lg">
        <InputGroup.Text id="inputGroup-sizing-lg">Large</InputGroup.Text>
        <Form.Control
          aria-label="Large"
          aria-describedby="inputGroup-sizing-sm"    >    aria-describedby="inputGroup-sizing-lg"
        />
</InputGroup>
```
In `area-describedby`, change `sm` to `lg`